### PR TITLE
BACKEND-17 fix missing permissions and configurations

### DIFF
--- a/stream/template.yaml
+++ b/stream/template.yaml
@@ -324,6 +324,9 @@ Resources:
           RDS_PORT: !Ref RDSPort
           RDS_HOSTNAME: !Ref RDSHostname
           RDS_SECRETARN: !Ref RDSSecretArn
+          RDS_USERNAME: !Ref RDSUsername
+          RDS_PASSWORD: !Ref RDSPassword
+          RDS_DB_NAME: !Ref RDSDBName
       Policies:
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Ref RDSSecretArn
@@ -394,6 +397,9 @@ Resources:
           RDS_PORT: !Ref RDSPort
           RDS_HOSTNAME: !Ref RDSHostname
           RDS_SECRETARN: !Ref RDSSecretArn
+          RDS_USERNAME: !Ref RDSUsername
+          RDS_PASSWORD: !Ref RDSPassword
+          RDS_DB_NAME: !Ref RDSDBName
       Policies:
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Ref RDSSecretArn


### PR DESCRIPTION
- All the Lambda functions were given appropriate permission to write to logs and attach/detach VPCs
- Added the missing environment variables of `GetStreamData`, `GetTransaction`, and `GetStats` Lambda functions
- Provide the user to config a VPC and subnets by adding new parameters for VPC and subnets: `VPCSecurityGroup`, `VPCSubnet1`, `VPCSubnet2`, and `VPCSubnet3`
- Renamed `RDSArn` parameter to `RDSProxyArn`