### PR TITLE
BACKEND-8 RDS multiple instance support

### DIFF
--- a/stream/template.yaml
+++ b/stream/template.yaml
@@ -189,6 +189,7 @@ Resources:
       EventSourceArn: !GetAtt TransactionBlockConsumer.ConsumerARN
       FunctionName: !GetAtt TransactionBlockPublisher.Arn
       StartingPosition: TRIM_HORIZON
+      ParallelizationFactor: 10
   GetStreamData:
     Type: AWS::Serverless::Function
     Properties:
@@ -211,7 +212,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -289,7 +290,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -360,7 +361,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -446,7 +447,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -621,6 +622,9 @@ Parameters:
   RDSHostname:
     Type: String
     Description: The hostname for the RDS database or RDS database proxy.
+  RDSReadOnlyHostname:
+    Type: String
+    Description: The read-only hostname for the RDS database or RDS database proxy.
   RDSSecretArn:
     Type: String
     Description: The ARN of the secret for the RDS database.

--- a/stream/templates/template_ondemand.yaml
+++ b/stream/templates/template_ondemand.yaml
@@ -201,7 +201,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -279,7 +279,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -350,7 +350,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -436,7 +436,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -514,7 +514,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -606,6 +606,9 @@ Parameters:
   RDSHostname:
     Type: String
     Description: The hostname for the RDS database or RDS database proxy.
+  RDSReadOnlyHostname:
+    Type: String
+    Description: The read-only hostname for the RDS database or RDS database proxy.
   RDSSecretArn:
     Type: String
     Description: The ARN of the secret for the RDS database.

--- a/stream/templates/template_ondemand_efo.yaml
+++ b/stream/templates/template_ondemand_efo.yaml
@@ -210,7 +210,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -288,7 +288,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -359,7 +359,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -445,7 +445,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -523,7 +523,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -620,6 +620,9 @@ Parameters:
   RDSHostname:
     Type: String
     Description: The hostname for the RDS database or RDS database proxy.
+  RDSReadOnlyHostname:
+    Type: String
+    Description: The read-only hostname for the RDS database or RDS database proxy.
   RDSSecretArn:
     Type: String
     Description: The ARN of the secret for the RDS database.

--- a/stream/templates/template_provisioned.yaml
+++ b/stream/templates/template_provisioned.yaml
@@ -202,7 +202,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -280,7 +280,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -351,7 +351,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -437,7 +437,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -515,7 +515,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -607,6 +607,9 @@ Parameters:
   RDSHostname:
     Type: String
     Description: The hostname for the RDS database or RDS database proxy.
+  RDSReadOnlyHostname:
+    Type: String
+    Description: The read-only hostname for the RDS database or RDS database proxy.
   RDSSecretArn:
     Type: String
     Description: The ARN of the secret for the RDS database.

--- a/stream/templates/template_provisioned_efo.yaml
+++ b/stream/templates/template_provisioned_efo.yaml
@@ -211,7 +211,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -289,7 +289,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -360,7 +360,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -446,7 +446,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -524,7 +524,7 @@ Resources:
       Environment:
         Variables:
           RDS_PORT: !Ref RDSPort
-          RDS_HOSTNAME: !Ref RDSHostname
+          RDS_HOSTNAME: !Ref RDSReadOnlyHostname
           RDS_SECRETARN: !Ref RDSSecretArn
           RDS_DB_NAME: !Ref RDSDBName
           RDS_REGION: !Ref AWS::Region
@@ -621,6 +621,9 @@ Parameters:
   RDSHostname:
     Type: String
     Description: The hostname for the RDS database or RDS database proxy.
+  RDSReadOnlyHostname:
+    Type: String
+    Description: The read-only hostname for the RDS database or RDS database proxy.
   RDSSecretArn:
     Type: String
     Description: The ARN of the secret for the RDS database.


### PR DESCRIPTION
Introduces a new SAM template parameter `RDSReadOnlyHostname`:
- Takes an RDS/RDS Proxy endpoint.
- Is connected to the `RDS_HOSTNAME` environment variable of API processing Lambda functions.
- The `TransactionBlockPublisher` Lambda function is still connected to the `RDSHostname` parameter.
- If multiple DB instances are used, use an endpoint with write accesses for the `RDSHostname` parameter and read access permission is sufficient for the endpoint connected to `RDSReadOnlyHostname`.
- If a single DB instance is used, use the same endpoint (with read/write permissions) for both `RDSReadOnlyHostname` and `RDSHostname`.